### PR TITLE
calc_evppi fix

### DIFF
--- a/R/evppi.R
+++ b/R/evppi.R
@@ -68,7 +68,7 @@ calc_evppi <- function(psa,
                        outcome = c("nmb_loss", "nhb_loss"),
                        type = c("gam", "poly"),
                        poly.order = 2,
-                       k = NA) {
+                       k = -1) {
   # define parameter values and make sure they correspond to a valid option
   type <- match.arg(type)
   outcome <- match.arg(outcome)

--- a/man/calc_evppi.Rd
+++ b/man/calc_evppi.Rd
@@ -6,7 +6,7 @@
 using a linear regression metamodel approach}
 \usage{
 calc_evppi(psa, wtp, parms = NULL, outcome = c("nmb_loss", "nhb_loss"),
-  type = c("gam", "poly"), poly.order = 2, k = NA)
+  type = c("gam", "poly"), poly.order = 2, k = -1)
 }
 \arguments{
 \item{psa}{object of class psa, produced by \code{\link{make_psa_obj}}}


### PR DESCRIPTION
Changed default k in calc_evppi to agree with expected default in metamodel()

Closes #68

This change allowed me to successfully run calc_evppi using the example PSA. Previous issue arose only when n_params=1, type = "gam", and k was unspecified (defaulted to NA). I tested edited code to run with different n_params, type = "poly" and "gam".

Package built, passed tests, and passed checks. I think I followed the general github protocols suggested by Caleb, but please let me know if there's something I should do differently. 