### PR TITLE
Gen psa cea

### DIFF
--- a/R/gen_psa_samp.R
+++ b/R/gen_psa_samp.R
@@ -223,7 +223,6 @@ gen_psa_samp <- function(params = NULL,
       names(params_df[[i]]) <- paste0(dists_params[[i]][, 1])
     }
 
-    #for size = length(dists_params[[i]][,1]) or size = sum(dists_params[[i]][,2])?
     #bootstrap
     if (dists[i] == "bootstrap") {
       samp_vec <- vector(mode = "numeric", length = nsamp)

--- a/R/psa.R
+++ b/R/psa.R
@@ -7,6 +7,28 @@
 #'
 #' @param parameters Data frame with values for each simulation (rows) and parameter (columns).
 #' The column names should be the parameter names.
+#'
+#' @param cost data frame containing data for costs if \code{run_psa_obj = NULL},
+#' or the name of the cost outcome if run_psa_obj is provided.
+#' For the data.frame, each simulation should be a row and each strategy should be a column.
+#' Naming the columns of the data frames is not necessary, as they will be renamed with
+#' the \code{strategies} vector.
+#' @param effectiveness data frame containing data for effectiveness if \code{run_psa_obj = NULL},
+#' or the name of the effectiveness outcome if run_psa_obj is provided.
+#' For the data.frame, each simulation should be a row and each strategy should be a column.
+#' Naming the columns of the data frames is not necessary, as they will be renamed with
+#' the \code{strategies} vector.
+#' @param other_outcome data frame containing data another outcome (user-defined).
+#' Each simulation should be a row of the data frame, and each strategy should be a column.
+#' Naming the columns of the data frames is not necessary, as they will be renamed with
+#' the \code{strategies} vector.
+#' @param strategies vector with the names of the strategies. Due to requirements in
+#' certain uses of this vector, this function uses \code{\link{make.names}} to modify
+#' strategy names as necessary. It is strongly suggested that you follow the rules
+#' in the \code{\link{make.names}} help page, to avoid unexpected errors.
+#'
+#' @param currency symbol for the currency being used (ex. "$", "£")
+#' @param run_psa_obj output from \code{\link{run_psa}}.
 #' @inheritParams create_sa
 #'
 #' @details
@@ -48,8 +70,34 @@
 #'
 #' @importFrom stringr str_replace
 #' @export
-make_psa_obj <- function(cost, effectiveness, parameters,
-                         strategies = NULL, currency = "$", other_outcome = NULL) {
+make_psa_obj <- function(cost, effectiveness, parameters = NULL,
+                         strategies = NULL, currency = "$", other_outcome = NULL,
+                         run_psa_obj = NULL) {
+
+  if (!is.null(run_psa_obj)) {
+
+    if (!is.character(c(cost, effectiveness))) {
+      stop(paste0("cost and effectiveness inputs must be corresponding outcome names from user-defined function if
+                  run_psa_obj is provided. Use the default, run_psa_obj = NULL, if  providing cost, effectiveness, and
+                  parameters data.frames directly."))
+    }
+
+    parameters <- run_psa_obj[[1]]$parameters
+    effectiveness <- run_psa_obj[[effectiveness]]$other_outcome
+    cost <- run_psa_obj[[cost]]$other_outcome
+  }
+
+  if (is.null(run_psa_obj)) {
+    if (!is.data.frame(other_outcome) & (!is.data.frame(cost) | !is.data.frame(cost))) {
+      stop(paste0("cost, effectiveness, and other_outcome inputs must be corresponding data.frames if
+                  run_psa_obj input is NULL"))
+    }
+  }
+
+  if (is.null(parameters)) {
+    stop(paste0("parameters data.frame must be provided if run_psa_obj input is NULL"))
+  }
+
   # parameter names
   parnames <- names(parameters)
 

--- a/R/run_psa.R
+++ b/R/run_psa.R
@@ -10,6 +10,7 @@
 #' @param outcomes String vector with the outcomes of interest from \code{FUN}.
 #' @param strategies vector of strategy names. The default \code{NULL} will use
 #' strategy names in \code{FUN}
+#'@param currency symbol for the currency being used (ex. "$", "£")
 #' @param ... Additional arguments to user-defined \code{FUN}
 #'
 #'
@@ -23,7 +24,7 @@
 #' @export
 
 run_psa <- function(psa_samp, FUN, outcomes = NULL,
-                    strategies = NULL, ...) {
+                    strategies = NULL, currency = "$", ...) {
 
   opt_arg_val <- list(...)
   fun_input_test <- c(list(psa_samp[1, ]), opt_arg_val)
@@ -82,15 +83,22 @@ run_psa <- function(psa_samp, FUN, outcomes = NULL,
       psa_out[[j]] <- make_psa_obj(cost = NULL, effectiveness = NULL,
                                    other_outcome = sim_out_df[[j]],
                                    parameters = psa_samp[, -1], strategies = strategies,
-                                   currency = "$")
+                                   currency = currency)
     }
 
 
     names(psa_out) <- outcomes
 
-    if (!is.null(cost_outcome) & !is.null(effectiveness_outcome)) {
+
+    effect_outcome <- intersect(outcomes, c("EFFECTIVENESS", "effectiveness", "Effectiveness",
+                                            "EFFECT", "effect", "Effect",
+                                            "EFFECTS", "effects", "Effects"))
+    cost_outcome <- intersect(outcomes, c("COST", "cost", "Cost",
+                                          "COSTS", "costs", "Costs"))
+
+    if (!is.null(cost_outcome) & !is.null(effect_outcome)) {
       cea_psa <- make_psa_obj(cost = sim_out_df[[cost_outcome]],
-                              effectiveness = sim_out_df[[effectiveness_outcome]],
+                              effectiveness = sim_out_df[[effect_outcome]],
                               parameters = psa_samp[, -1], strategies = strategies,
                               currency = currency)
       psa_out <- append(list(cea_psa), psa_out)

--- a/R/run_psa.R
+++ b/R/run_psa.R
@@ -85,6 +85,17 @@ run_psa <- function(psa_samp, FUN, outcomes = NULL,
                                    currency = "$")
     }
 
+
     names(psa_out) <- outcomes
+
+    if (!is.null(cost_outcome) & !is.null(effectiveness_outcome)) {
+      cea_psa <- make_psa_obj(cost = sim_out_df[[cost_outcome]],
+                              effectiveness = sim_out_df[[effectiveness_outcome]],
+                              parameters = psa_samp[, -1], strategies = strategies,
+                              currency = currency)
+      psa_out <- append(list(cea_psa), psa_out)
+      names(psa_out) <- c("cea_psa", outcomes)
+    }
+
     return(psa_out)
   }

--- a/man/make_psa_obj.Rd
+++ b/man/make_psa_obj.Rd
@@ -7,22 +7,23 @@
 make_psa_obj(
   cost,
   effectiveness,
-  parameters,
+  parameters = NULL,
   strategies = NULL,
   currency = "$",
-  other_outcome = NULL
+  other_outcome = NULL,
+  run_psa_obj = NULL
 )
 }
 \arguments{
-\item{cost}{data frames containing data for costs,
-effectiveness or another outcome (user-defined), respectively.
-Each simulation should be a row of the data frame, and each strategy should be a column.
+\item{cost}{data frame containing data for costs if \code{run_psa_obj = NULL},
+or the name of the cost outcome if run_psa_obj is provided.
+For the data.frame, each simulation should be a row and each strategy should be a column.
 Naming the columns of the data frames is not necessary, as they will be renamed with
 the \code{strategies} vector.}
 
-\item{effectiveness}{data frames containing data for costs,
-effectiveness or another outcome (user-defined), respectively.
-Each simulation should be a row of the data frame, and each strategy should be a column.
+\item{effectiveness}{data frame containing data for effectiveness if \code{run_psa_obj = NULL},
+or the name of the effectiveness outcome if run_psa_obj is provided.
+For the data.frame, each simulation should be a row and each strategy should be a column.
 Naming the columns of the data frames is not necessary, as they will be renamed with
 the \code{strategies} vector.}
 
@@ -36,8 +37,7 @@ in the \code{\link{make.names}} help page, to avoid unexpected errors.}
 
 \item{currency}{symbol for the currency being used (ex. "$", "£")}
 
-\item{other_outcome}{data frames containing data for costs,
-effectiveness or another outcome (user-defined), respectively.
+\item{other_outcome}{data frame containing data another outcome (user-defined).
 Each simulation should be a row of the data frame, and each strategy should be a column.
 Naming the columns of the data frames is not necessary, as they will be renamed with
 the \code{strategies} vector.}

--- a/man/make_psa_obj.Rd
+++ b/man/make_psa_obj.Rd
@@ -41,6 +41,8 @@ in the \code{\link{make.names}} help page, to avoid unexpected errors.}
 Each simulation should be a row of the data frame, and each strategy should be a column.
 Naming the columns of the data frames is not necessary, as they will be renamed with
 the \code{strategies} vector.}
+
+\item{run_psa_obj}{output from \code{\link{run_psa}}.}
 }
 \value{
 An object of class \code{psa}

--- a/man/run_psa.Rd
+++ b/man/run_psa.Rd
@@ -4,7 +4,7 @@
 \alias{run_psa}
 \title{Calculate outcomes for a PSA using a user-defined function.}
 \usage{
-run_psa(psa_samp, FUN, outcomes = NULL, strategies = NULL, ...)
+run_psa(psa_samp, FUN, outcomes = NULL, strategies = NULL, currency = "$", ...)
 }
 \arguments{
 \item{psa_samp}{A dataframe with samples of parameters for a probabilistic sensitivity analysis (PSA)}
@@ -17,6 +17,8 @@ where the first column are the strategy names and the rest of the columns must b
 
 \item{strategies}{vector of strategy names. The default \code{NULL} will use
 strategy names in \code{FUN}}
+
+\item{currency}{symbol for the currency being used (ex. "$", "£")}
 
 \item{...}{Additional arguments to user-defined \code{FUN}}
 }

--- a/vignettes/psa_generation.Rmd
+++ b/vignettes/psa_generation.Rmd
@@ -196,13 +196,9 @@ psa_output <- run_psa(psa_samp = l_params_all,
                       outcomes = c("Cost", "Effect", "NMB"),
                       strategies = c("No_Treatment", "Treatment"))
 
-### outcomes are stored in "other_outcome" and we need to make a psa object 
-### that specifies which outcomes are costs and effects in order to do CEA
-cea_psa <- make_psa_obj(cost = psa_output$Cost$other_outcome, 
-                        effect = psa_output$Effect$other_outcome, 
-                        parameters = psa_output$Cost$parameters,
-                        strategies = psa_output$Cost$strategies,
-                        currency = "$")
+# Becasue cost and effect outcomes were present, a psa object compatible 
+# with downstream dampack functions was automatically created as the first list element of psa_output
+cea_psa <- psa_output[[1]]
 
 ### demonstrating the passing of extra parameters to calculated_ce_out (n_wtp)
 psa_output2 <- run_psa(psa_samp = l_params_all, 

--- a/vignettes/psa_generation.Rmd
+++ b/vignettes/psa_generation.Rmd
@@ -200,12 +200,17 @@ psa_output <- run_psa(psa_samp = l_params_all,
 # with downstream dampack functions was automatically created as the first list element of psa_output
 cea_psa <- psa_output[[1]]
 
+cea_psa <- make_psa_obj(cost = "Cost",
+                        effectiveness = "Effect", 
+                        run_psa_obj = psa_output, 
+                        strategies = c("No_Treatment", "Treatment"))
+
 ### demonstrating the passing of extra parameters to calculated_ce_out (n_wtp)
 psa_output2 <- run_psa(psa_samp = l_params_all, 
-                      FUN = calculate_ce_out,
-                      outcomes = c("Cost", "Effect", "NMB"),
-                      strategies = c("No_Treatment", "Treatment"), 
-                      n_wtp = 50000)
+                       FUN = calculate_ce_out,
+                       outcomes = c("Cost", "Effect", "NMB"),
+                       strategies = c("No_Treatment", "Treatment"), 
+                       n_wtp = 50000)
 
 ```
 


### PR DESCRIPTION
On this branch and the master branch, I've updated the run_owsa_det and run_twsa_det functions to take 1) a list of basecase values for all parameters and, 2) a smaller data.frame containing only the parameters of interest ("pars"), and the min and max values for the DSA's. 

On this branch, I've put in two changes:

1) run_psa will create a "psa" object with costs and effects that is compatible with downstream psa functions if it automatically detects some version of "costs"/"cost" and "effect"/"effectiveness" within the outcomes specified by the user in the user-defined function. This psa object will be the first element in the list returned by run_psa. This way, the user won't have to call make_psa_obj if the cost and effect outcomes are explicitly named as such.

2) make_psa_obj can take a "run_psa_obj" as an optional input. If run_psa_obj is provided, the cost and effect inputs must be names of the corresponding outcomes rather than data.frames containing all of the cost and effect output data. Allowing make_psa_obj to work in this way convoluted the function inputs a bit, so please let me know if you have any suggestions to make this more clear or efficient. I could create distinct inputs for the outcome names corresponding to cost and effect rather than changing the behavior of the "cost" and "effectiveness" inputs dependent upon the existence of the "run_psa_obj" input.

Your email only suggested making the second change I described for this branch, so let me know if you would want me to undo the first change. Alternatively, I could add an option to run_psa that allows the user to specify which outcomes correspond to cost and effectiveness so that run_psa can directly spit out the fully functional psa object without having to adjust make_psa_obj() at all. Sorry for taking a while to get to this--finals slowed me down a little bit.