### PR TITLE
Rename the summary.ceac optimal strategy column and cover it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 -Added calculate_icers_psa function
 -Added argument to plot.owsa and plot.twsa for the plotting of specific points (e.g. base case values) on top of default plot
 
+### Breaking Changes
+-summary.ceac renames its third output column from `cost_eff_strat` to `optimal_strategy`. Code that referred to the old column name by `$cost_eff_strat` must be updated (#173)
+
 ### Bug Fixes
 -summary.ceac no longer returns duplicated, mislabeled, and NA-range rows when the cost-effectiveness frontier switches optimal strategy two or more times. It now returns one row per interval (#173)
 

--- a/R/ceac.R
+++ b/R/ceac.R
@@ -246,9 +246,11 @@ plot.ceac <- function(x,
 #'
 #' @param object object returned from the \code{ceac} function
 #' @param ... further arguments (not used)
-#' @return data frame showing the interval of cost effectiveness for each
-#' interval. The intervals are open on the right endpoint -
-#' i.e., [\code{range_min}, \code{range_max})
+#' @return data frame with one row per interval of willingness to pay over which
+#' a single strategy is optimal, and three columns: \code{range_min} and
+#' \code{range_max} bounding the interval, and \code{optimal_strategy} naming the
+#' strategy on the cost-effectiveness frontier there. The intervals are open on
+#' the right endpoint - i.e., [\code{range_min}, \code{range_max})
 #'
 #' @keywords internal
 #'
@@ -305,6 +307,6 @@ summary.ceac <- function(object, ...) {
       }
     }
   }
-  names(sum_df) <- c("range_min", "range_max", "cost_eff_strat")
+  names(sum_df) <- c("range_min", "range_max", "optimal_strategy")
   sum_df
 }

--- a/man/summary.ceac.Rd
+++ b/man/summary.ceac.Rd
@@ -12,9 +12,11 @@
 \item{...}{further arguments (not used)}
 }
 \value{
-data frame showing the interval of cost effectiveness for each
-interval. The intervals are open on the right endpoint -
-i.e., [\code{range_min}, \code{range_max})
+data frame with one row per interval of willingness to pay over which
+a single strategy is optimal, and three columns: \code{range_min} and
+\code{range_max} bounding the interval, and \code{optimal_strategy} naming the
+strategy on the cost-effectiveness frontier there. The intervals are open on
+the right endpoint - i.e., [\code{range_min}, \code{range_max})
 }
 \description{
 Describes cost-effective strategies and their

--- a/tests/testthat/test_ceac.R
+++ b/tests/testthat/test_ceac.R
@@ -41,7 +41,7 @@ test_that("handles missing strategy", {
 test_that("message is correct in summary.ceac", {
   c <- ceac(wtp, psa_obj)
   sum_df <- summary(c)
-  expect_equal(sum_df$cost_eff_strat, c("Radio", "Chemo"))
+  expect_equal(sum_df$optimal_strategy, c("Radio", "Chemo"))
 })
 
 test_that("summary.ceac is correct when the frontier switches twice", {
@@ -55,7 +55,31 @@ test_that("summary.ceac is correct when the frontier switches twice", {
   expect_equal(nrow(sum_df), 3)
   expect_equal(sum_df$range_min, c(10000, 50000, 70000))
   expect_equal(sum_df$range_max, c(50000, 70000, 90000))
-  expect_equal(sum_df$cost_eff_strat, c("A", "B", "C"))
+  expect_equal(sum_df$optimal_strategy, c("A", "B", "C"))
+})
+
+test_that("summary.ceac summarizes a real psa whose frontier switches many times", {
+  # df_example_psa_elc switches optimal strategy three times, so the summary must
+  # have four intervals. built through the public api - make_psa_obj() then
+  # ceac() - so the test also proves the bad shape was reachable from real data,
+  # which a hand-built ceac object cannot.
+  data("df_example_psa_elc")
+  l_psa <- make_psa_obj(cost = df_example_psa_elc[, 1:6],
+                        effectiveness = df_example_psa_elc[, 7:12])
+  df_ceac <- ceac(seq(1000, 150000, 1000), l_psa)
+  df_sum <- summary(df_ceac)
+
+  # expected intervals derived independently, by run-length encoding the frontier
+  df_front <- df_ceac[df_ceac$On_Frontier == TRUE, ]
+  l_runs <- rle(as.character(df_front$Strategy))
+  v_starts <- c(1, head(cumsum(l_runs$lengths), -1) + 1)
+
+  expect_equal(nrow(df_sum), length(l_runs$values))
+  expect_equal(df_sum$optimal_strategy, l_runs$values)
+  expect_equal(df_sum$range_min, df_front$WTP[v_starts])
+  expect_equal(df_sum$range_max, c(df_front$WTP[v_starts[-1]], max(df_front$WTP)))
+  expect_false(anyNA(df_sum))
+  expect_equal(anyDuplicated(df_sum), 0L)
 })
 
 ## plot


### PR DESCRIPTION
## Summary

Renames the third column returned by `summary.ceac` from `cost_eff_strat` to
`optimal_strategy`, documents the return value properly, and adds a regression
test that drives a real PSA sample through the public interface. Completes the
work begun in #173, whose row-generation fix is already on `dev`.

## What changed

- `R/ceac.R`:
  - The third output column of `summary.ceac`, and the `@return` section describing it.
  - Renamed `cost_eff_strat` to `optimal_strategy`; the return docs previously named only `range_min` and `range_max`, never the column users actually index by.
  - The old name read as an abbreviation, and an undocumented return column is easy to depend on by accident.
  - Makes the contract explicit: two bounding columns and the strategy on the frontier between them.

- `tests/testthat/test_ceac.R`:
  - Expectations moved to the new column name, plus a regression test over `df_example_psa_elc`.
  - Existing coverage built a `ceac` object by hand, which cannot demonstrate the bad shape was reachable through the public interface.
  - Drives the dataset through `make_psa_obj` and `ceac`, deriving expected intervals independently by run-length encoding the frontier rather than restating the implementation.
  - Locks row count, ranges and labels against a frontier that switches three times.

- `man/summary.ceac.Rd`:
  - Regenerated help page.
  - Roxygen output is tracked in this package rather than built on install.

- `NEWS.md`:
  - Breaking Changes bullet for the rename.
  - Renaming an output column silently breaks code indexing the old name, so it cannot ship unannounced.

## Notes

- `R CMD check` is clean on this branch: Status OK, no errors, warnings or notes. Tarball 3.7 MB.
- Full suite is 162 passing. The one failing test is the `lintr` style gate tracked in #179 — 80 lints, 64 of them in two vignettes, none introduced here.
- The before/after demonstration script is deliberately not included; it is a working aid rather than package content and would ship in the tarball.
- Strategy names still cannot contain spaces: `make_psa_obj` reaches `create_sa`, which applies `make.names` at `R/create_sa.R:73` and rewrites `Strategy 1` to `Strategy.1`. That limitation is unaddressed and has no issue of its own yet.

---
Project: dampack Date: 11-August-2026 10:30 AM PT
Branch: 173-summary-ceac-frontier-switches → Base: dev
Issue: #173 | Version: #172
